### PR TITLE
Fix: Failed to create query: empty String

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -255,6 +255,10 @@ class EP_PHP_Proxy {
 				continue;
 			}
 
+			if ( empty( $value ) ) {
+				continue;
+			}
+
 			$taxonomy = $matches[1];
 
 			$relation = ( ! empty( $tax_relations[ $taxonomy ] ) ) ?
@@ -266,6 +270,7 @@ class EP_PHP_Proxy {
 				'terms'    => array_map( [ $this, 'sanitize_number' ], explode( ',', $value ) ),
 			];
 		}
+
 		if ( empty( $taxonomies ) ) {
 			return;
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the plugin throws the error `Failed to create query: empty String` when no term is being selected in the taxonomy filter

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes [#3098](https://github.com/10up/ElasticPress/issues/3098)

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Search for any term on frontend.
- Select a Taxonomy Term.
- Unselect the Same Taxonomy Term.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - `Failed to create query: empty String` when no term is selected in taxonomy filter. 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
