### PR TITLE
Relocate proxy file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "name": "stellarwp/elasticpress-proxy",
+    "type": "wordpress-plugin",
+    "version": "1.0.0"
+}

--- a/elasticpress-proxy.php
+++ b/elasticpress-proxy.php
@@ -52,11 +52,9 @@ function save_template( $search_template ) {
 
 	$file_content = implode( "\n", $file_content );
 
-	$uploads_dir = wp_upload_dir();
-
 	$wp_filesystem->put_contents(
-		trailingslashit( $uploads_dir['basedir'] ) . 'ep-custom-proxy-credentials.php',
-		$file_content
+        trailingslashit( WP_CONTENT_DIR ) . 'ep-custom-proxy.php',
+        $file_content
 	);
 }
 add_action( 'ep_instant_results_template_saved', __NAMESPACE__ . '\save_template' );

--- a/proxy.php
+++ b/proxy.php
@@ -78,7 +78,7 @@ class EP_PHP_Proxy {
 		 *
 		 * It contains the template query, credentials, and the endpoint URL.
 		 */
-		require '../../uploads/ep-custom-proxy-credentials.php';
+		require '../../ep-custom-proxy.php';
 
 		$this->query          = $query_template;
 		$this->post_index_url = $post_index_url;


### PR DESCRIPTION
The out of the box proxy plugin example does not take the possibility of S3 Uploads. 

These changes move the file to the content directory instead, to avoid the S3 conflicts. 


Note: I believe we need to be able to update the version number of the plugin in order to trigger an update with Composer. 

Not sure about the procedure for updating a forked plugin. 